### PR TITLE
[TP-61] 로거 추가

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -20,6 +20,7 @@ repositories {
 object Versions {
     const val KOTEST = "4.6.3"
     const val SWAGGER = "3.0.0"
+    const val KOTLIN_LOGGING = "1.12.5"
 }
 
 dependencies {
@@ -34,6 +35,7 @@ dependencies {
     implementation("org.flywaydb:flyway-core")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("io.github.microutils:kotlin-logging:${Versions.KOTLIN_LOGGING}")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("mysql:mysql-connector-java")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/server/src/main/resources/logback-spring.xml
+++ b/server/src/main/resources/logback-spring.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?> <!DOCTYPE configuration>
+<configuration>
+    <springProfile name="test, local">
+        <include resource="logback/logback-console.xml"/>
+    </springProfile>
+    <springProfile name="dev, prod">
+        <include resource="logback/logback-file.xml"/>
+    </springProfile>
+</configuration>
+

--- a/server/src/main/resources/logback/logback-console.xml
+++ b/server/src/main/resources/logback/logback-console.xml
@@ -1,0 +1,13 @@
+<included>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</included>
+

--- a/server/src/main/resources/logback/logback-file.xml
+++ b/server/src/main/resources/logback/logback-file.xml
@@ -1,0 +1,25 @@
+<included>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <property name="LOG_FILE_BASE" value="myapp"/>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>log/${LOG_FILE_BASE}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>log/${LOG_FILE_BASE}.log.%d{yyyyMMdd}.%i</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>500MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>60</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
+            <immediateFlush>${IMMEDIATE_FLUSH}</immediateFlush>
+        </encoder>
+    </appender>
+    <appender name="ASYNC_FILE" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <appender-ref ref="FILE"/>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="ASYNC_FILE"/>
+    </root>
+</included>


### PR DESCRIPTION
코틀린에서 사용하는 경량 로깅 라이브러리 kotlin-logger를 적용했습니다.
slf4j를 래핑한 라이브러리라서 자바에서 설정하던 방법과 거의 같아 쉽게 사용 가능합니다.

자바에서는 `@Slf4j`라는 롬복에서 제공해주는 라이브러리를 사용했는데, 코틀린에는 그런게 따로 없습니다.
그래서 클래스 선언부 위에 아래 코드를 추가해서 로거 적용하시면 됩니다.
우려되는 부분은 KotlinLogging 라이브러리 의존성이 로그를 사용하는 모든 구간에 퍼진다는건데, 적절한 처리 방법을 더 찾아봐야 할 것 같습니다. 좋은 아이디어 있으면 공유해주세요. 개인적으로는 [이 링크](https://hippolab.tistory.com/69)를 따라해보면 괜찮을 것 같다는 생각이 듭니다.

```kotlin
private val logger = KotlinLogging.logger {}
```

로거 설정은 일단 크게 손대지 않고 간단하게 콘솔/파일로만 나누고 프로파일도 테스트/로컬/개발/프로덕션정도만 나누어 뒀습니다.


- [공식 레퍼런스](https://github.com/MicroUtils/kotlin-logging)
- [참고 링크](https://jungseob86.tistory.com/17)
