### PR TITLE
[TP-74] 버튼 스타일 미적용 오류 해결

### DIFF
--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -39,9 +39,8 @@ const Container = styled.button<ContainerProps>`
   padding: 8px 16px;
   border-radius: 24px;
   font-weight: 700;
-  
-  width: ${({ width }) => (width ? width : 'auto')}};
 
+  width: ${({ width }) => (width ? width : 'auto')};
   ${({ variant }) => variantCSS[variant]};
   ${({ size }) => sizeCSS[size]};
 `;


### PR DESCRIPTION
```tsx
  width: ${({ width }) => (width ? width : 'auto')}};
```
위에서 아래로 변경되었습니다.
```tsx
  width: ${({ width }) => (width ? width : 'auto')};
```

위에꺼가 `}`가 하나 더 많네요.
next에서는 이걸 제대로 반영하지 못했고, 왜인지 스토리북에선 그냥 씹고 스타일 적용해주네요.
ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ아 왜 쓸데없이 배려해주는데 ㅋㅋㅋㅋㅋ

IDE에서도 오류로 못잡고,,,
하다보니 하나 알아낸 것은
webstorm에서는 백틱 안에서 자동완성이 안된다면, 그 위 어딘가에 오류가 나고 있을 거란 거네요.
다시 재현해보니 `width: ~`부분 뒤에서부턴 자동완성이 안됩니다. `}`하나 빼니까 되고요.
하,,,,,