### PR TITLE
[TP-86] 이미지 업로드 검증로직 추가 및 문서화

### DIFF
--- a/server/src/main/kotlin/com/tilbox/api/image/application/ImageUploadService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/image/application/ImageUploadService.kt
@@ -8,18 +8,19 @@ import java.util.UUID
 @Transactional
 @Service
 class ImageUploadService(private val imageUploader: ImageUploader) {
-    fun upload(image: MultipartFile): ImageUploadResponse {
-        requireNotNull(image.originalFilename) { "올바르지 않은 이미지입니다." }
-        val fileName = generateFileName(image.originalFilename!!)
-        return image.inputStream.use { stream ->
+    fun upload(imageFile: MultipartFile): String {
+        requireNotNull(imageFile.originalFilename) { "올바르지 않은 이미지입니다." }
+        val fileName = generateFileName(imageFile.originalFilename!!)
+        val response = imageFile.inputStream.use { stream ->
             imageUploader.upload(
                 ImageUploadRequest(
                     stream,
-                    image.size,
+                    imageFile.size,
                     fileName
                 )
             )
         }
+        return response.url
     }
 
     private fun generateFileName(originalFileName: String): String {

--- a/server/src/main/kotlin/com/tilbox/api/image/ui/ImageController.kt
+++ b/server/src/main/kotlin/com/tilbox/api/image/ui/ImageController.kt
@@ -1,22 +1,40 @@
 package com.tilbox.api.image.ui
 
-import com.tilbox.api.image.application.ImageUploadResponse
 import com.tilbox.api.image.application.ImageUploadService
+import com.tilbox.common.validation.ImageFile
 import io.swagger.annotations.Api
+import io.swagger.annotations.ApiResponse
+import io.swagger.annotations.ApiResponses
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
+import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
+import java.net.URI
 
 @Api(description = "이미지")
+@Validated
 @RestController
 @RequestMapping("/v1/images")
 class ImageController(private val imageUploadService: ImageUploadService) {
-    @PostMapping("/upload")
-    fun upload(@RequestPart imageFile: MultipartFile): ResponseEntity<ImageUploadResponse> {
-        val response = imageUploadService.upload(imageFile)
-        return ResponseEntity.ok(response)
+    @Operation(summary = "이미지 업로드", description = "이미지 파일을 업로드한다.")
+    @PostMapping("/upload", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @ApiResponses(
+        ApiResponse(code = 200, message = "이미지 파일 업로드 실패"),
+        ApiResponse(code = 400, message = "올바르지 않은 이미지 파일 형식")
+    )
+    fun upload(
+        @Parameter(
+            description = "업로드 할 이미지 파일",
+            required = true
+        ) @RequestPart @ImageFile imageFile: MultipartFile
+    ): ResponseEntity<Void> {
+        val url = imageUploadService.upload(imageFile)
+        return ResponseEntity.created(URI(url)).build()
     }
 }

--- a/server/src/main/kotlin/com/tilbox/common/validation/ImageFile.kt
+++ b/server/src/main/kotlin/com/tilbox/common/validation/ImageFile.kt
@@ -1,0 +1,15 @@
+package com.tilbox.common.validation
+
+import javax.validation.Constraint
+import javax.validation.Payload
+import kotlin.reflect.KClass
+
+@MustBeDocumented
+@Constraint(validatedBy = [ImageFileValidator::class])
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.FIELD, AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ImageFile(
+    val message: String = "올바르지 않은 파일 형식입니다.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = []
+)

--- a/server/src/main/kotlin/com/tilbox/common/validation/ImageFileValidator.kt
+++ b/server/src/main/kotlin/com/tilbox/common/validation/ImageFileValidator.kt
@@ -1,7 +1,6 @@
 package com.tilbox.common.validation
 
 import org.springframework.web.multipart.MultipartFile
-import java.util.Objects
 import javax.validation.ConstraintValidator
 import javax.validation.ConstraintValidatorContext
 
@@ -9,15 +8,11 @@ val ALLOWED_CONTENT_TYPES = listOf("image/gif", "image/png", "image/jpg", "image
 
 class ImageFileValidator : ConstraintValidator<ImageFile?, MultipartFile> {
     override fun isValid(file: MultipartFile, context: ConstraintValidatorContext): Boolean {
-        val contentType = getContentType(file)
+        val contentType = file.contentType ?: return false
         return isSupportedContentType(contentType)
     }
 
-    private fun getContentType(file: MultipartFile): String? {
-        return Objects.requireNonNull(file.contentType, "파일 형식을 찾을 수 없습니다.")
-    }
-
-    private fun isSupportedContentType(contentType: String?): Boolean {
+    private fun isSupportedContentType(contentType: String): Boolean {
         return ALLOWED_CONTENT_TYPES.any { it == contentType }
     }
 }

--- a/server/src/main/kotlin/com/tilbox/common/validation/ImageFileValidator.kt
+++ b/server/src/main/kotlin/com/tilbox/common/validation/ImageFileValidator.kt
@@ -1,0 +1,25 @@
+package com.tilbox.common.validation
+
+import org.springframework.web.multipart.MultipartFile
+import java.util.Objects
+import javax.validation.ConstraintValidator
+import javax.validation.ConstraintValidatorContext
+
+val ALLOWED_CONTENT_TYPES = listOf("image/gif", "image/png", "image/jpg", "image/jpeg")
+
+class ImageFileValidator : ConstraintValidator<ImageFile?, MultipartFile> {
+    override fun initialize(constraintAnnotation: ImageFile?) {}
+
+    override fun isValid(file: MultipartFile, context: ConstraintValidatorContext): Boolean {
+        val contentType = getContentType(file)
+        return isSupportedContentType(contentType)
+    }
+
+    private fun getContentType(file: MultipartFile): String? {
+        return Objects.requireNonNull(file.contentType, "파일 형식을 찾을 수 없습니다.")
+    }
+
+    private fun isSupportedContentType(contentType: String?): Boolean {
+        return ALLOWED_CONTENT_TYPES.any { it == contentType }
+    }
+}

--- a/server/src/main/kotlin/com/tilbox/common/validation/ImageFileValidator.kt
+++ b/server/src/main/kotlin/com/tilbox/common/validation/ImageFileValidator.kt
@@ -8,8 +8,6 @@ import javax.validation.ConstraintValidatorContext
 val ALLOWED_CONTENT_TYPES = listOf("image/gif", "image/png", "image/jpg", "image/jpeg")
 
 class ImageFileValidator : ConstraintValidator<ImageFile?, MultipartFile> {
-    override fun initialize(constraintAnnotation: ImageFile?) {}
-
     override fun isValid(file: MultipartFile, context: ConstraintValidatorContext): Boolean {
         val contentType = getContentType(file)
         return isSupportedContentType(contentType)

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -49,9 +49,3 @@ springfox:
         swagger-ui:
             base-url: /documentation
 
-logging:
-    level:
-        com:
-            amazonaws:
-                util:
-                    EC2MetadataUtils: error


### PR DESCRIPTION
- [X] spring cloud에서 사용하던 로그설정 제거
- [X] 이미지 컨텐트타입을 png, jpg, jpeg, gif만 받도록 커스텀 validator 추가
- [X] 이미지 업로드 API 문서화
- [X] 이미지 업로드 API 응답을 요청 body가 아닌 Location Header로 하도록 변경

전역 예외에 대한 응답코드 처리는 #48 에서 처리됨