### PR TITLE
[TP-77] 게시물 좋아요, 좋아요 취소 구현

### DIFF
--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
@@ -1,0 +1,21 @@
+package com.tilbox.api.like_post.application
+
+import com.tilbox.core.like_post.domain.LikePost
+import com.tilbox.core.like_post.domain.LikePostRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@Service
+class LikePostService(private val likePostRepository: LikePostRepository) {
+    fun like(postId: Long, userId: Long) {
+        check(
+            !likePostRepository.existsByPostIdAndUserId(
+                postId,
+                userId
+            )
+        ) { "이미 좋아요를 클릭한 게시물입니다. postId=$postId, userId=$userId" }
+
+        likePostRepository.save(LikePost(postId, userId))
+    }
+}

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
@@ -16,6 +16,7 @@ class LikePostService(private val likePostRepository: LikePostRepository) {
             )
         ) { "이미 좋아요를 클릭한 게시물입니다. postId=$postId, userId=$userId" }
 
-        likePostRepository.save(LikePost(postId, userId))
+        val savedLikePost = likePostRepository.save(LikePost(postId, userId))
+        savedLikePost.like()
     }
 }

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
@@ -21,7 +21,6 @@ class LikePostService(
             )
         ) { "이미 좋아요를 클릭한 게시물입니다. postId=$postId, userId=$userId" }
 
-        val savedLikePost = likePostRepository.save(LikePost(postId, userId))
-        savedLikePost.like()
+        likePostRepository.save(LikePost(postId, userId).like())
     }
 }

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/LikePostService.kt
@@ -2,13 +2,18 @@ package com.tilbox.api.like_post.application
 
 import com.tilbox.core.like_post.domain.LikePost
 import com.tilbox.core.like_post.domain.LikePostRepository
+import com.tilbox.core.post.domain.repository.PostRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Transactional
 @Service
-class LikePostService(private val likePostRepository: LikePostRepository) {
+class LikePostService(
+    private val postRepository: PostRepository,
+    private val likePostRepository: LikePostRepository
+) {
     fun like(postId: Long, userId: Long) {
+        check(postRepository.existsById(postId)) { "게시물이 존재하지 않습니다. postId=$postId, userId=$userId" }
         check(
             !likePostRepository.existsByPostIdAndUserId(
                 postId,

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
@@ -12,10 +12,9 @@ class UnlikePostService(
     private val likePostRepository: LikePostRepository
 ) {
     fun unlike(postId: Long, userId: Long) {
-        check(postRepository.existsById(postId)) { "게시물이 존재하지 않습니다." }
+        check(postRepository.existsById(postId)) { "게시물이 존재하지 않습니다. postId=$postId, userId=$userId" }
         val likePost = likePostRepository.findByPostIdAndUserId(postId, userId)
             .orElseThrow { IllegalStateException("게시물에 좋아요가 존재하지 않습니다. postId=$postId, userId=$userId") }
-        likePost.unlike()
-        likePostRepository.delete(likePost)
+        likePostRepository.delete(likePost.unlike())
     }
 }

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
@@ -10,6 +10,7 @@ class UnlikePostService(private val likePostRepository: LikePostRepository) {
     fun unlike(postId: Long, userId: Long) {
         val likePost = likePostRepository.findByPostIdAndUserId(postId, userId)
             .orElseThrow { IllegalStateException("게시물에 좋아요가 존재하지 않습니다. postId=$postId, userId=$userId") }
+        likePost.unlike()
         likePostRepository.delete(likePost)
     }
 }

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
@@ -5,8 +5,8 @@ import com.tilbox.core.post.domain.repository.PostRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
-@Service
 @Transactional
+@Service
 class UnlikePostService(
     private val postRepository: PostRepository,
     private val likePostRepository: LikePostRepository

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
@@ -1,13 +1,18 @@
 package com.tilbox.api.like_post.application
 
 import com.tilbox.core.like_post.domain.LikePostRepository
+import com.tilbox.core.post.domain.repository.PostRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 @Transactional
-class UnlikePostService(private val likePostRepository: LikePostRepository) {
+class UnlikePostService(
+    private val postRepository: PostRepository,
+    private val likePostRepository: LikePostRepository
+) {
     fun unlike(postId: Long, userId: Long) {
+        check(postRepository.existsById(postId)) { "게시물이 존재하지 않습니다." }
         val likePost = likePostRepository.findByPostIdAndUserId(postId, userId)
             .orElseThrow { IllegalStateException("게시물에 좋아요가 존재하지 않습니다. postId=$postId, userId=$userId") }
         likePost.unlike()

--- a/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/application/UnlikePostService.kt
@@ -1,0 +1,15 @@
+package com.tilbox.api.like_post.application
+
+import com.tilbox.core.like_post.domain.LikePostRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class UnlikePostService(private val likePostRepository: LikePostRepository) {
+    fun unlike(postId: Long, userId: Long) {
+        val likePost = likePostRepository.findByPostIdAndUserId(postId, userId)
+            .orElseThrow { IllegalStateException("게시물에 좋아요가 존재하지 않습니다. postId=$postId, userId=$userId") }
+        likePostRepository.delete(likePost)
+    }
+}

--- a/server/src/main/kotlin/com/tilbox/api/like_post/ui/LikePostRestController.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/ui/LikePostRestController.kt
@@ -1,0 +1,29 @@
+package com.tilbox.api.like_post.ui
+
+import com.tilbox.api.like_post.application.LikePostService
+import com.tilbox.api.like_post.application.UnlikePostService
+import com.tilbox.api.security.LoginUserId
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("posts")
+class LikePostRestController(
+    private val likePostService: LikePostService,
+    private val unlikePostService: UnlikePostService
+) {
+    @PostMapping("/{postId}/like")
+    fun like(@PathVariable postId: Long, @LoginUserId userId: Long): ResponseEntity<Void> {
+        likePostService.like(postId, userId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @PostMapping("/{postId}/unlike")
+    fun unlike(@PathVariable postId: Long, @LoginUserId userId: Long): ResponseEntity<Void> {
+        unlikePostService.unlike(postId, userId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/server/src/main/kotlin/com/tilbox/api/like_post/ui/LikePostRestController.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/ui/LikePostRestController.kt
@@ -3,12 +3,14 @@ package com.tilbox.api.like_post.ui
 import com.tilbox.api.like_post.application.LikePostService
 import com.tilbox.api.like_post.application.UnlikePostService
 import com.tilbox.api.security.LoginUserId
+import io.swagger.annotations.Api
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Api(description = "TIL 게시글 좋아요 API")
 @RestController
 @RequestMapping("posts")
 class LikePostRestController(

--- a/server/src/main/kotlin/com/tilbox/api/like_post/ui/LikePostRestController.kt
+++ b/server/src/main/kotlin/com/tilbox/api/like_post/ui/LikePostRestController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController
 
 @Api(description = "TIL 게시글 좋아요 API")
 @RestController
-@RequestMapping("posts")
+@RequestMapping("/v1/posts")
 class LikePostRestController(
     private val likePostService: LikePostService,
     private val unlikePostService: UnlikePostService

--- a/server/src/main/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateService.kt
@@ -1,0 +1,22 @@
+package com.tilbox.api.post.application
+
+import com.tilbox.core.like_post.domain.LikePostEvent
+import com.tilbox.core.post.domain.repository.PostRepository
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Service
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Service
+class PostLikeCountUpdateService(private val postRepository: PostRepository) {
+    @Async
+    @TransactionalEventListener
+    fun increaseLikeCount(likePostEvent: LikePostEvent) {
+        postRepository.increaseLikeCount(likePostEvent.postId)
+    }
+
+    @Async
+    @TransactionalEventListener
+    fun decreaseLikeCount(likePostEvent: LikePostEvent) {
+        postRepository.decreaseLikeCount(likePostEvent.userId)
+    }
+}

--- a/server/src/main/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateService.kt
+++ b/server/src/main/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateService.kt
@@ -1,11 +1,15 @@
 package com.tilbox.api.post.application
 
 import com.tilbox.core.like_post.domain.LikePostEvent
+import com.tilbox.core.like_post.domain.UnlikePostEvent
 import com.tilbox.core.post.domain.repository.PostRepository
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.transaction.event.TransactionalEventListener
 
+@Transactional(propagation = Propagation.REQUIRES_NEW)
 @Service
 class PostLikeCountUpdateService(private val postRepository: PostRepository) {
     @Async
@@ -16,7 +20,7 @@ class PostLikeCountUpdateService(private val postRepository: PostRepository) {
 
     @Async
     @TransactionalEventListener
-    fun decreaseLikeCount(likePostEvent: LikePostEvent) {
-        postRepository.decreaseLikeCount(likePostEvent.userId)
+    fun decreaseLikeCount(unlikePostEvent: UnlikePostEvent) {
+        postRepository.decreaseLikeCount(unlikePostEvent.userId)
     }
 }

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePost.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePost.kt
@@ -17,11 +17,13 @@ class LikePost(
 
     id: Long = 0L
 ) : BaseRootEntity<LikePost>(id) {
-    fun like() {
+    fun like(): LikePost {
         this.registerEvent(LikePostEvent(postId, userId))
+        return this
     }
 
-    fun unlike() {
+    fun unlike(): LikePost {
         this.registerEvent(UnlikePostEvent(postId, userId))
+        return this
     }
 }

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePost.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePost.kt
@@ -1,0 +1,19 @@
+package com.tilbox.core.like_post.domain
+
+import com.tilbox.core.base.BaseRootEntity
+import javax.persistence.Column
+import javax.persistence.Entity
+import javax.persistence.Index
+import javax.persistence.Table
+
+@Table(indexes = [Index(name = "user_liked_post_idx", columnList = "user_id,post_id", unique = true)])
+@Entity
+class LikePost(
+    @Column(name = "post_id", nullable = false)
+    val postId: Long,
+
+    @Column(name = "user_id", nullable = false)
+    val userId: Long,
+
+    id: Long = 0L
+) : BaseRootEntity<LikePost>(id)

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePost.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePost.kt
@@ -16,4 +16,12 @@ class LikePost(
     val userId: Long,
 
     id: Long = 0L
-) : BaseRootEntity<LikePost>(id)
+) : BaseRootEntity<LikePost>(id) {
+    fun like() {
+        this.registerEvent(LikePostEvent(postId, userId))
+    }
+
+    fun unlike() {
+        this.registerEvent(UnlikePostEvent(postId, userId))
+    }
+}

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePostEvent.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePostEvent.kt
@@ -1,0 +1,3 @@
+package com.tilbox.core.like_post.domain
+
+data class LikePostEvent(val postId: Long, val userId: Long)

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePostRepository.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePostRepository.kt
@@ -1,0 +1,12 @@
+package com.tilbox.core.like_post.domain
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface LikePostRepository : JpaRepository<LikePost, Long> {
+    fun findByPostIdAndUserId(postId: Long, userId: Long): Optional<LikePost>
+
+    fun existsByPostIdAndUserId(postId: Long, userId: Long): Boolean
+}

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePostRepository.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/LikePostRepository.kt
@@ -1,10 +1,8 @@
 package com.tilbox.core.like_post.domain
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.stereotype.Repository
 import java.util.Optional
 
-@Repository
 interface LikePostRepository : JpaRepository<LikePost, Long> {
     fun findByPostIdAndUserId(postId: Long, userId: Long): Optional<LikePost>
 

--- a/server/src/main/kotlin/com/tilbox/core/like_post/domain/UnlikePostEvent.kt
+++ b/server/src/main/kotlin/com/tilbox/core/like_post/domain/UnlikePostEvent.kt
@@ -1,0 +1,3 @@
+package com.tilbox.core.like_post.domain
+
+data class UnlikePostEvent(val postId: Long, val userId: Long)

--- a/server/src/main/kotlin/com/tilbox/core/post/domain/entity/Post.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/domain/entity/Post.kt
@@ -41,7 +41,7 @@ class Post(
     private var visibleLevel: PostVisibleLevel,
 
     @Column(name = "like_count", nullable = false)
-    private var likeCount: Long = 0,
+    var likeCount: Long = 0,
 
     @Column(name = "created_at", nullable = false)
     private val createdAt: LocalDateTime,

--- a/server/src/main/kotlin/com/tilbox/core/post/domain/repository/PostRepository.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/domain/repository/PostRepository.kt
@@ -2,5 +2,15 @@ package com.tilbox.core.post.domain.repository
 
 import com.tilbox.core.post.domain.entity.Post
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 
-interface PostRepository : JpaRepository<Post, Long>
+interface PostRepository : JpaRepository<Post, Long> {
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 where p.id = :id")
+    fun increaseLikeCount(id: Long)
+
+    @Modifying
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 where p.id = :id")
+    fun decreaseLikeCount(id: Long)
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -14,9 +14,10 @@ spring:
             idle-timeout: 600000
             max-lifetime: 1800000
             transaction-isolation: TRANSACTION_READ_COMMITTED
-        url: jdbc:h2:mem:tilbox;DB_CLOSE_ON_EXIT=FALSE
+        url: jdbc:h2:mem:tilbox
         username: tilbox
         password: retrospective6
+        driver-class-name: org.h2.Driver
     jpa:
         generate-ddl: true
         open-in-view: false

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
@@ -1,32 +1,67 @@
 package com.tilbox.api.like_post.application
 
+import com.tilbox.core.like_post.domain.LikePostRepository
+import com.tilbox.core.post.domain.entity.Post
+import com.tilbox.core.post.domain.fixture.ofDefaultPost
+import com.tilbox.core.post.domain.repository.PostRepository
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.optional.shouldBePresent
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
-import javax.transaction.Transactional
+import org.springframework.transaction.annotation.Transactional
 
 @Transactional
 @ActiveProfiles("test")
 @SpringBootTest
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class LikePostServiceTest(private val likePostService: LikePostService) {
-    private val postId = 1L
-    private val userId = 1L
+class LikePostServiceTest(
+    private val likePostService: LikePostService,
+    private val postRepository: PostRepository,
+    private val likePostRepository: LikePostRepository
+) {
+    private lateinit var 게시물: Post
+    private val 사용자_ID = 1L
+
+    @BeforeEach
+    fun setUp() {
+        게시물 = `게시물을 저장한다`()
+    }
 
     @Test
     fun `게시물 좋아요를 생성한다`() {
-        likePostService.like(postId, userId)
+        `좋아요를 생성한다`(게시물.id, 사용자_ID)
+
+        val actual = likePostRepository.findByPostIdAndUserId(게시물.id, 사용자_ID)
+        actual shouldBePresent { it.id shouldNotBe null }
+    }
+
+    @Test
+    fun `게시물이 존재하지 않는 경우 좋아요를 할 수 없다`() {
+        val actual = shouldThrow<IllegalStateException> { `좋아요를 생성한다`(150L, 사용자_ID) }
+
+        actual.message shouldStartWith "게시물이 존재하지 않습니다."
     }
 
     @Test
     fun `게시물 좋아요가 이미 존재하는 경우 예외가 발생한다`() {
-        likePostService.like(postId, userId)
+        `좋아요를 생성한다`(게시물.id, 사용자_ID)
 
-        val actual = shouldThrow<IllegalStateException> { likePostService.like(postId, userId) }
+        val actual = shouldThrow<IllegalStateException> { `좋아요를 생성한다`(게시물.id, 사용자_ID) }
 
         actual.message shouldStartWith "이미 좋아요를 클릭한 게시물입니다."
+    }
+
+    private fun `게시물을 저장한다`(): Post {
+        val post = postRepository.save(ofDefaultPost())
+        return post
+    }
+
+    private fun `좋아요를 생성한다`(postId: Long, userId: Long) {
+        likePostService.like(postId, userId)
     }
 }

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
@@ -14,6 +14,8 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
 import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @Transactional
 @ActiveProfiles("test")
@@ -35,6 +37,8 @@ class LikePostServiceTest(
     @Test
     fun `게시물 좋아요를 생성한다`() {
         `좋아요를 생성한다`(게시물.id, 사용자_ID)
+
+        CountDownLatch(1).await(2000, TimeUnit.MILLISECONDS)
 
         val actual = likePostRepository.findByPostIdAndUserId(게시물.id, 사용자_ID)
         actual shouldBePresent { it.id shouldNotBe null }

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
@@ -1,0 +1,32 @@
+package com.tilbox.api.like_post.application
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
+import javax.transaction.Transactional
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class LikePostServiceTest(private val likePostService: LikePostService) {
+    private val postId = 1L
+    private val userId = 1L
+
+    @Test
+    fun `게시물 좋아요를 생성한다`() {
+        likePostService.like(postId, userId)
+    }
+
+    @Test
+    fun `게시물 좋아요가 이미 존재하는 경우 예외가 발생한다`() {
+        likePostService.like(postId, userId)
+
+        val actual = shouldThrow<IllegalStateException> { likePostService.like(postId, userId) }
+
+        actual.message shouldStartWith "이미 좋아요를 클릭한 게시물입니다."
+    }
+}

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/LikePostServiceTest.kt
@@ -1,5 +1,6 @@
 package com.tilbox.api.like_post.application
 
+import com.tilbox.base.test.DatabaseCleanUp
 import com.tilbox.core.like_post.domain.LikePostRepository
 import com.tilbox.core.post.domain.entity.Post
 import com.tilbox.core.post.domain.fixture.ofDefaultPost
@@ -8,8 +9,10 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.optional.shouldBePresent
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
@@ -26,12 +29,20 @@ class LikePostServiceTest(
     private val postRepository: PostRepository,
     private val likePostRepository: LikePostRepository
 ) {
+    @field:Autowired
+    private lateinit var databaseCleanUp: DatabaseCleanUp
+
     private lateinit var 게시물: Post
     private val 사용자_ID = 1L
 
     @BeforeEach
     fun setUp() {
         게시물 = `게시물을 저장한다`()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncate()
     }
 
     @Test

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/UnlikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/UnlikePostServiceTest.kt
@@ -1,5 +1,6 @@
 package com.tilbox.api.like_post.application
 
+import com.tilbox.base.test.DatabaseCleanUp
 import com.tilbox.core.like_post.domain.LikePost
 import com.tilbox.core.like_post.domain.LikePostRepository
 import com.tilbox.core.post.domain.entity.Post
@@ -7,8 +8,10 @@ import com.tilbox.core.post.domain.fixture.ofDefaultPost
 import com.tilbox.core.post.domain.repository.PostRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
@@ -23,12 +26,20 @@ class UnlikePostServiceTest(
     private val postRepository: PostRepository,
     private val likePostRepository: LikePostRepository
 ) {
+    @field:Autowired
+    private lateinit var databaseCleanUp: DatabaseCleanUp
+
     private lateinit var 게시물: Post
     private val 사용자_ID = 1L
 
     @BeforeEach
     fun setUp() {
         게시물 = `게시물을 저장한다`()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncate()
     }
 
     @Test

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/UnlikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/UnlikePostServiceTest.kt
@@ -1,0 +1,37 @@
+package com.tilbox.api.like_post.application
+
+import com.tilbox.core.like_post.domain.LikePost
+import com.tilbox.core.like_post.domain.LikePostRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestConstructor
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class UnlikePostServiceTest(
+    private val unlikePostService: UnlikePostService,
+    private val likePostRepository: LikePostRepository
+) {
+    private val postId = 1L
+    private val userId = 1L
+
+    @Test
+    fun `좋아요를 취소한다`() {
+        likePostRepository.save(LikePost(postId, userId))
+
+        unlikePostService.unlike(postId, userId)
+    }
+
+    @Test
+    fun `좋아요가 존재하지 않는 경우 취소할 수 없다`() {
+        val actual = shouldThrow<IllegalStateException> { unlikePostService.unlike(postId, userId) }
+
+        actual.message shouldStartWith "게시물에 좋아요가 존재하지 않습니다."
+    }
+}

--- a/server/src/test/kotlin/com/tilbox/api/like_post/application/UnlikePostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/application/UnlikePostServiceTest.kt
@@ -2,8 +2,12 @@ package com.tilbox.api.like_post.application
 
 import com.tilbox.core.like_post.domain.LikePost
 import com.tilbox.core.like_post.domain.LikePostRepository
+import com.tilbox.core.post.domain.entity.Post
+import com.tilbox.core.post.domain.fixture.ofDefaultPost
+import com.tilbox.core.post.domain.repository.PostRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
@@ -16,22 +20,41 @@ import org.springframework.transaction.annotation.Transactional
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class UnlikePostServiceTest(
     private val unlikePostService: UnlikePostService,
+    private val postRepository: PostRepository,
     private val likePostRepository: LikePostRepository
 ) {
-    private val postId = 1L
-    private val userId = 1L
+    private lateinit var 게시물: Post
+    private val 사용자_ID = 1L
+
+    @BeforeEach
+    fun setUp() {
+        게시물 = `게시물을 저장한다`()
+    }
 
     @Test
     fun `좋아요를 취소한다`() {
-        likePostRepository.save(LikePost(postId, userId))
+        `좋아요를 생성한다`(게시물.id, 사용자_ID)
 
-        unlikePostService.unlike(postId, userId)
+        `좋아요를 취소한다`(게시물.id, 사용자_ID)
     }
 
     @Test
     fun `좋아요가 존재하지 않는 경우 취소할 수 없다`() {
-        val actual = shouldThrow<IllegalStateException> { unlikePostService.unlike(postId, userId) }
+        val actual = shouldThrow<IllegalStateException> { `좋아요를 취소한다`(게시물.id, 사용자_ID) }
 
         actual.message shouldStartWith "게시물에 좋아요가 존재하지 않습니다."
+    }
+
+    private fun `게시물을 저장한다`(): Post {
+        val post = postRepository.save(ofDefaultPost())
+        return post
+    }
+
+    private fun `좋아요를 생성한다`(postId: Long, userId: Long) {
+        likePostRepository.save(LikePost(postId, userId))
+    }
+
+    private fun `좋아요를 취소한다`(postId: Long, userId: Long) {
+        unlikePostService.unlike(postId, userId)
     }
 }

--- a/server/src/test/kotlin/com/tilbox/api/like_post/ui/LikePostRestControllerTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/ui/LikePostRestControllerTest.kt
@@ -22,7 +22,7 @@ class LikePostRestControllerTest : RestControllerTest() {
         justRun { likePostService.like(any(), any()) }
 
         // when
-        val actual = post("/posts/1/like")
+        val actual = post("/v1/posts/1/like")
 
         // then
         actual.andExpect {
@@ -36,7 +36,7 @@ class LikePostRestControllerTest : RestControllerTest() {
         justRun { unlikePostService.unlike(any(), any()) }
 
         // when
-        val actual = post("/posts/1/unlike")
+        val actual = post("/v1/posts/1/unlike")
 
         // then
         actual.andExpect {

--- a/server/src/test/kotlin/com/tilbox/api/like_post/ui/LikePostRestControllerTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/like_post/ui/LikePostRestControllerTest.kt
@@ -1,0 +1,46 @@
+package com.tilbox.api.like_post.ui
+
+import com.ninjasquad.springmockk.MockkBean
+import com.tilbox.api.like_post.application.LikePostService
+import com.tilbox.api.like_post.application.UnlikePostService
+import com.tilbox.base.test.RestControllerTest
+import io.mockk.justRun
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+
+@WebMvcTest(controllers = [LikePostRestController::class])
+class LikePostRestControllerTest : RestControllerTest() {
+    @MockkBean
+    private lateinit var likePostService: LikePostService
+
+    @MockkBean
+    private lateinit var unlikePostService: UnlikePostService
+
+    @Test
+    fun `게시물에 좋아요를 누른다`() {
+        // given
+        justRun { likePostService.like(any(), any()) }
+
+        // when
+        val actual = post("/posts/1/like")
+
+        // then
+        actual.andExpect {
+            status { isNoContent() }
+        }
+    }
+
+    @Test
+    fun `게시물 좋아요를 취소한다`() {
+        // given
+        justRun { unlikePostService.unlike(any(), any()) }
+
+        // when
+        val actual = post("/posts/1/unlike")
+
+        // then
+        actual.andExpect {
+            status { isNoContent() }
+        }
+    }
+}

--- a/server/src/test/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateServiceTest.kt
@@ -1,0 +1,52 @@
+package com.tilbox.api.post.application
+
+import com.tilbox.api.like_post.application.LikePostService
+import com.tilbox.api.like_post.application.UnlikePostService
+import com.tilbox.core.post.domain.entity.Post
+import com.tilbox.core.post.domain.fixture.ofDefaultPost
+import com.tilbox.core.post.domain.repository.PostRepository
+import io.kotest.matchers.longs.shouldBeExactly
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.TestConstructor
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@SpringBootTest
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+class PostLikeCountUpdateServiceTest(
+    private val likePostService: LikePostService,
+    private val unlikePostService: UnlikePostService,
+    private val postRepository: PostRepository
+) {
+    private val countDownLatch = CountDownLatch(1)
+    private lateinit var 게시물: Post
+
+    @BeforeEach
+    fun setUp() {
+        게시물 = postRepository.save(ofDefaultPost())
+    }
+
+    @Test
+    fun `좋아요 이벤트가 발생하면 좋아요 수가 1 증가한다`() {
+        likePostService.like(게시물.id, 1L)
+        countDownLatch.await(2_000L, TimeUnit.MILLISECONDS)
+
+        val actual = postRepository.findById(게시물.id).get()
+        actual.likeCount shouldBeExactly 1L
+    }
+
+    @Test
+    fun `좋아요 취소 이벤트가 발생하면 좋아요 수가 1 감소한다`() {
+        likePostService.like(게시물.id, 1L)
+        unlikePostService.unlike(게시물.id, 1L)
+
+        countDownLatch.await(2_000L, TimeUnit.MILLISECONDS)
+
+        val actual = postRepository.findById(게시물.id).get()
+        actual.likeCount shouldBeExactly 0L
+    }
+}

--- a/server/src/test/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateServiceTest.kt
@@ -54,8 +54,8 @@ class PostLikeCountUpdateServiceTest(
     @Test
     fun `좋아요 취소 이벤트가 발생하면 좋아요 수가 1 감소한다`() {
         likePostService.like(게시물.id, 1L)
-        unlikePostService.unlike(게시물.id, 1L)
 
+        unlikePostService.unlike(게시물.id, 1L)
         countDownLatch.await(2_000L, TimeUnit.MILLISECONDS)
 
         val actual = postRepository.findById(게시물.id).get()

--- a/server/src/test/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/post/application/PostLikeCountUpdateServiceTest.kt
@@ -2,32 +2,44 @@ package com.tilbox.api.post.application
 
 import com.tilbox.api.like_post.application.LikePostService
 import com.tilbox.api.like_post.application.UnlikePostService
+import com.tilbox.base.test.DatabaseCleanUp
 import com.tilbox.core.post.domain.entity.Post
 import com.tilbox.core.post.domain.fixture.ofDefaultPost
 import com.tilbox.core.post.domain.repository.PostRepository
 import io.kotest.matchers.longs.shouldBeExactly
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest
+@ActiveProfiles("test")
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
 class PostLikeCountUpdateServiceTest(
     private val likePostService: LikePostService,
     private val unlikePostService: UnlikePostService,
     private val postRepository: PostRepository
 ) {
+    @field:Autowired
+    private lateinit var databaseCleanUp: DatabaseCleanUp
+
     private val countDownLatch = CountDownLatch(1)
+
     private lateinit var 게시물: Post
 
     @BeforeEach
     fun setUp() {
         게시물 = postRepository.save(ofDefaultPost())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncate()
     }
 
     @Test

--- a/server/src/test/kotlin/com/tilbox/api/post/application/PostServiceTest.kt
+++ b/server/src/test/kotlin/com/tilbox/api/post/application/PostServiceTest.kt
@@ -1,5 +1,6 @@
 package com.tilbox.api.post.application
 
+import com.tilbox.base.test.DatabaseCleanUp
 import com.tilbox.core.post.domain.fixture.ofDefaultCreateRequest
 import com.tilbox.core.post.domain.fixture.ofDefaultPost
 import com.tilbox.core.post.domain.fixture.ofDefaultUpdateRequest
@@ -7,7 +8,9 @@ import com.tilbox.core.post.domain.repository.PostRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestConstructor
@@ -22,6 +25,14 @@ class PostServiceTest(
     private val postService: PostService,
     private val postRepository: PostRepository
 ) {
+    @field:Autowired
+    private lateinit var databaseCleanUp: DatabaseCleanUp
+
+    @AfterEach
+    fun tearDown() {
+        databaseCleanUp.truncate()
+    }
+
     @Test
     fun `게시글 작성시 새로 생성된 게시글 ID를 반환한다`() {
         val createRequest = ofDefaultCreateRequest()

--- a/server/src/test/kotlin/com/tilbox/base/test/DatabaseCleanUp.kt
+++ b/server/src/test/kotlin/com/tilbox/base/test/DatabaseCleanUp.kt
@@ -28,7 +28,8 @@ class DatabaseCleanUp constructor(private val entityManager: EntityManager) :
                 convertCamelToSnakeCase(it.name)
             }
         embeddedTableNames =
-            (entityManager.metamodel as MetamodelImpl).collectionPersisters().values.map { (it as BasicCollectionPersister).tableName }
+            (entityManager.metamodel as MetamodelImpl)
+                .collectionPersisters().values.map { (it as BasicCollectionPersister).tableName }
     }
 
     @Transactional

--- a/server/src/test/kotlin/com/tilbox/base/test/DatabaseCleanUp.kt
+++ b/server/src/test/kotlin/com/tilbox/base/test/DatabaseCleanUp.kt
@@ -1,5 +1,7 @@
 package com.tilbox.base.test
 
+import org.hibernate.metamodel.internal.MetamodelImpl
+import org.hibernate.persister.collection.BasicCollectionPersister
 import org.springframework.beans.factory.InitializingBean
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Service
@@ -12,8 +14,10 @@ import kotlin.reflect.full.findAnnotation
 @Service
 @Profile("test")
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
-class DatabaseCleanUp constructor(private val entityManager: EntityManager) : InitializingBean {
+class DatabaseCleanUp constructor(private val entityManager: EntityManager) :
+    InitializingBean {
     private lateinit var tableNames: List<String>
+    private lateinit var embeddedTableNames: List<String>
 
     override fun afterPropertiesSet() {
         tableNames = entityManager.metamodel.entities
@@ -23,6 +27,8 @@ class DatabaseCleanUp constructor(private val entityManager: EntityManager) : In
             .map {
                 convertCamelToSnakeCase(it.name)
             }
+        embeddedTableNames =
+            (entityManager.metamodel as MetamodelImpl).collectionPersisters().values.map { (it as BasicCollectionPersister).tableName }
     }
 
     @Transactional
@@ -33,6 +39,9 @@ class DatabaseCleanUp constructor(private val entityManager: EntityManager) : In
             entityManager.createNativeQuery("TRUNCATE TABLE $tableName").executeUpdate()
             entityManager.createNativeQuery("ALTER TABLE $tableName ALTER COLUMN id RESTART WITH 1")
                 .executeUpdate()
+        }
+        embeddedTableNames.forEach { tableName ->
+            entityManager.createNativeQuery("TRUNCATE TABLE $tableName").executeUpdate()
         }
         entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate()
     }

--- a/server/src/test/kotlin/com/tilbox/base/test/RestControllerTest.kt
+++ b/server/src/test/kotlin/com/tilbox/base/test/RestControllerTest.kt
@@ -63,6 +63,12 @@ abstract class RestControllerTest {
         }
     }
 
+    protected fun post(path: String): ResultActionsDsl {
+        return mockMvc.post(path) {
+            accept = MediaType.APPLICATION_JSON
+        }
+    }
+
     protected fun post(path: String, request: Any): ResultActionsDsl {
         return mockMvc.post(path) {
             content = objectMapper.writeValueAsBytes(request)


### PR DESCRIPTION
## 기능

- [X] 게시물 좋아요 생성
- [X] 게시물 좋아요가 이미 존재하는 경우 예외 발생
- [X] 게시물 좋아요 취소
- [X] 게시물 좋아요가 존재하지 않는 경우 예외 발생
- [x] 게시물 좋아요 발생시 게시물 좋아요 수 증가
- [x] 게시물 좋아요 취소 발생시 게시물 좋아요 수 감소

## 고려사항

- 게시물 좋아요 증감시 update 쿼리를 통해 데이터 일관성 보장
- 게시물 좋아요/좋아요 취소시 이벤트 발행하고, 이벤트 구독자가 게시물 좋아요 수 변경하도록 구현
- 게시물 좋아요 이벤트 구독자를 비동기로 동작하도록 구현
- 게시물 좋아요 도메인은 독립적인 애그리거트를 가지도록 구현하여 사용자, 게시물과의 의존 관계를 최소화
  - 사용자, 게시물이 보장해야 할 불변식이 없으므로 이와 같이 구현해도 무방하다고 판단
- 게시물 좋아요는 복합 명사이므로 패키지 네이밍시 underscore(_)를 이용하여 명명
  - e.g. `com.tilbox.core.like_post`