### PR TITLE
[TP-94] QueryDSL 설정 추가

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -4,9 +4,14 @@ plugins {
     id("org.springframework.boot") version "2.5.5"
     id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("org.jlleitschuh.gradle.ktlint") version "10.2.0"
-    kotlin("jvm") version "1.5.31"
-    kotlin("plugin.spring") version "1.5.31"
-    kotlin("plugin.jpa") version "1.5.31"
+
+    val kotlinVersion = "1.5.31"
+
+    kotlin("jvm") version kotlinVersion
+    kotlin("kapt") version kotlinVersion
+    kotlin("plugin.spring") version kotlinVersion
+    kotlin("plugin.jpa") version kotlinVersion
+    kotlin("plugin.allopen") version kotlinVersion
 }
 
 group = "com"
@@ -44,6 +49,9 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("software.amazon.awssdk:s3:${Versions.AWS_SDK}")
 
+    implementation("com.querydsl:querydsl-jpa")
+    kapt(group = "com.querydsl", name = "querydsl-apt", classifier = "jpa")
+
     implementation("io.github.microutils:kotlin-logging:${Versions.KOTLIN_LOGGING}")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("mysql:mysql-connector-java")
@@ -69,4 +77,8 @@ tasks.withType<KotlinCompile> {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+kotlin.sourceSets.main {
+    setBuildDir("$buildDir")
 }

--- a/server/src/main/kotlin/com/tilbox/api/config/QueryDslConfig.kt
+++ b/server/src/main/kotlin/com/tilbox/api/config/QueryDslConfig.kt
@@ -1,0 +1,13 @@
+package com.tilbox.api.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QueryDslConfig(@PersistenceContext val entityManager: EntityManager) {
+    @Bean
+    fun jpaQueryFactory() = JPAQueryFactory(entityManager)
+}


### PR DESCRIPTION
- querydsl 설정 추가
- querydsl 사용에 필요한 bean 등록

### 특이사항

빌드 후 생성된 Q 클래스를 프로젝트 내에서 참조하기 위해서는 `build.gradle`에 다음 설정을 추가해야 합니다.

```kotlin
sourceSets.main {
    withConvention(org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet::class) {
        kotlin.srcDir("$buildDir/generated/source/kapt/main")
    }
}
```

![image](https://user-images.githubusercontent.com/20358042/150679752-40b82170-f6f4-41e1-b418-f56b62d11f04.png)

> 'withConvention(KClass<ConventionType>, ConventionType.() -> ReturnType): ReturnType' is deprecated. The concept of conventions is deprecated. Use extensions instead.

그러나 위 방식은 gradle version 7.x부터 deprecated 되었으므로 아래와 같은 방식으로 변경 가능합니다. 더 깔끔해졌죠?

```kotlin
kotlin.sourceSets.main {
    setBuildDir("$buildDir")
}
```

### 참고

- https://joomn11.tistory.com/5
- https://pasudo123.tistory.com/472