### PR TITLE
[TP-95] 로그인 API 호출시 response body에 access token 포함

### DIFF
--- a/server/src/main/kotlin/com/tilbox/api/user/application/LoginResponse.kt
+++ b/server/src/main/kotlin/com/tilbox/api/user/application/LoginResponse.kt
@@ -1,3 +1,3 @@
 package com.tilbox.api.user.application
 
-data class LoginResponse(val token: String)
+data class LoginResponse(val accessToken: String)

--- a/server/src/main/kotlin/com/tilbox/api/user/ui/LoginRestController.kt
+++ b/server/src/main/kotlin/com/tilbox/api/user/ui/LoginRestController.kt
@@ -29,8 +29,8 @@ class LoginRestController(private val loginService: LoginService) {
         val response = loginService.login(request)
 
         return ResponseEntity.ok()
-            .header(HttpHeaders.AUTHORIZATION, response.token)
-            .build()
+            .header(HttpHeaders.AUTHORIZATION, response.accessToken)
+            .body(response)
     }
 
     @Operation(summary = "로그아웃", description = "로그아웃을 진행한다.")


### PR DESCRIPTION
@hwookim

로그인 API 응답 body에 accessToken 추가했습니다.

![image](https://user-images.githubusercontent.com/20358042/150785491-89d9a189-ecee-4150-9980-972887423047.png)

swagger 문서도 업데이트 되어 있습니다😊

테스트 해보시고 문제 없으면 바로 머지 부탁드립니다!