### PR TITLE
[TP-95] 게시물 조회 기능 추가

### DIFF
--- a/server/src/main/kotlin/com/tilbox/api/post/ui/PostRestController.kt
+++ b/server/src/main/kotlin/com/tilbox/api/post/ui/PostRestController.kt
@@ -3,12 +3,15 @@ package com.tilbox.api.post.ui
 import com.tilbox.api.post.application.PostService
 import com.tilbox.api.post.application.dto.request.PostCreateRequest
 import com.tilbox.api.security.LoginUserId
+import com.tilbox.core.post.query.PostQueryDao
+import com.tilbox.core.post.query.UserPostQueryRequest
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiResponse
 import io.swagger.annotations.ApiResponses
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -19,10 +22,12 @@ import java.net.URI
 import java.time.LocalDateTime
 import javax.validation.Valid
 
+const val DEFAULT_PAGE_SIZE = 20L
+
 @Api(description = "TIL 게시글 API")
 @RestController
 @RequestMapping("/v1/posts")
-class PostRestController(private val postService: PostService) {
+class PostRestController(private val postService: PostService, private val postQueryDao: PostQueryDao) {
 
     @Operation(summary = "새 게시글 저장", description = "새로운 게시글을 생성한다.")
     @ApiResponses(
@@ -66,4 +71,8 @@ class PostRestController(private val postService: PostService) {
         postService.remove(postId, userId)
         return ResponseEntity.noContent().build()
     }
+
+    @GetMapping("/my")
+    fun readMyPosts(@LoginUserId userId: Long, size: Long?, lastPostId: Long, keyword: String?) =
+        postQueryDao.readUserPosts(UserPostQueryRequest(lastPostId, size ?: DEFAULT_PAGE_SIZE, userId, keyword, null))
 }

--- a/server/src/main/kotlin/com/tilbox/common/exception/GlobalExceptionHandler.kt
+++ b/server/src/main/kotlin/com/tilbox/common/exception/GlobalExceptionHandler.kt
@@ -36,7 +36,7 @@ class GlobalExceptionHandler {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(value = [Exception::class])
     fun handleInternalException(exception: Exception): ApiErrorResponse {
-        log.error { exception.stackTrace }
+        log.error { exception.stackTraceToString() }
         return ApiErrorResponse(message = "알 수 없는 에러가 발생했습니다.")
     }
 }

--- a/server/src/main/kotlin/com/tilbox/core/post/domain/entity/Post.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/domain/entity/Post.kt
@@ -18,36 +18,36 @@ import javax.persistence.Lob
 @TypeDef(name = "json", typeClass = JsonType::class)
 class Post(
     @Column(name = "user_id", nullable = false)
-    private val userId: Long,
+    val userId: Long,
 
     @Column(name = "title", nullable = false, length = 40)
-    private var title: String,
+    var title: String,
 
     @Lob
-    private var content: String,
+    var content: String,
 
     @Column(name = "summary", nullable = false, length = 150)
-    private var summary: String,
+    var summary: String,
 
     @Embedded
-    private var tags: Tags,
+    var tags: Tags,
 
     @Type(type = "json")
     @Column(name = "thumbnail", nullable = false, columnDefinition = "json")
-    private var thumbnail: String,
+    var thumbnail: String,
 
     @Column(name = "visible_level", nullable = false, length = 10)
     @Enumerated(EnumType.STRING)
-    private var visibleLevel: PostVisibleLevel,
+    var visibleLevel: PostVisibleLevel,
 
     @Column(name = "like_count", nullable = false)
-    private var likeCount: Long = 0,
+    var likeCount: Long = 0,
 
     @Column(name = "created_at", nullable = false)
-    private val createdAt: LocalDateTime,
+    val createdAt: LocalDateTime,
 
     @Column(name = "modified_at", nullable = false)
-    private var updatedAt: LocalDateTime,
+    var updatedAt: LocalDateTime,
 
     id: Long = 0L
 ) : BaseRootEntity<Post>(id) {

--- a/server/src/main/kotlin/com/tilbox/core/post/domain/value/Tag.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/domain/value/Tag.kt
@@ -6,5 +6,5 @@ import javax.persistence.Embeddable
 @Embeddable
 class Tag(
     @Column(nullable = false, length = 10)
-    private val name: String
+    val name: String
 )

--- a/server/src/main/kotlin/com/tilbox/core/post/domain/value/Tags.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/domain/value/Tags.kt
@@ -24,7 +24,7 @@ class Tags(
             Index(name = "idx_tag_name", columnList = "name")
         ]
     )
-    private val items: MutableList<Tag> = mutableListOf()
+    val items: MutableList<Tag> = mutableListOf()
 ) {
     companion object {
         fun of(items: List<String>): Tags {

--- a/server/src/main/kotlin/com/tilbox/core/post/query/PostQueryDao.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/query/PostQueryDao.kt
@@ -1,0 +1,25 @@
+package com.tilbox.core.post.query
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.tilbox.core.post.domain.entity.QPost.post
+import com.tilbox.core.user.domain.QUser.user
+import org.springframework.stereotype.Component
+
+@Component
+class PostQueryDao(private val queryFactory: JPAQueryFactory) {
+    fun readUserPosts(request: UserPostQueryRequest): List<UserPostQueryResponse> =
+        queryFactory.select(QUserPostQueryResponse(post, user)).from(post)
+            .join(user).on(anyUserPost(request.userId))
+            .fetchJoin()
+            .where(lessThanPostId(request.lastPostId), containsKeywordInTitle(request.keyword))
+            .orderBy(post.createdAt.desc())
+            .limit(request.size)
+            .fetch()
+
+    private fun anyUserPost(userId: Long) = post.userId.eq(user.id).and(user.id.eq(userId))
+
+    private fun lessThanPostId(lastPostId: Long?) = lastPostId?.let { post.id.lt(it) }
+
+    private fun containsKeywordInTitle(keyword: String?) =
+        keyword?.let { post.title.contains(it).or(post.content.contains(it)) }
+}

--- a/server/src/main/kotlin/com/tilbox/core/post/query/UserPostQueryRequest.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/query/UserPostQueryRequest.kt
@@ -1,0 +1,9 @@
+package com.tilbox.core.post.query
+
+data class UserPostQueryRequest(
+    val lastPostId: Long?,
+    val size: Long,
+    val userId: Long,
+    val keyword: String?,
+    val likedUser: Boolean?
+)

--- a/server/src/main/kotlin/com/tilbox/core/post/query/UserPostQueryResponse.kt
+++ b/server/src/main/kotlin/com/tilbox/core/post/query/UserPostQueryResponse.kt
@@ -1,0 +1,35 @@
+package com.tilbox.core.post.query
+
+import com.querydsl.core.annotations.QueryProjection
+import com.tilbox.core.post.domain.entity.Post
+import com.tilbox.core.user.domain.User
+import java.time.LocalDateTime
+
+data class UserPostQueryResponse(
+    val postId: Long,
+    val userId: Long,
+    val profile: String?,
+    val nickname: String,
+    val tilAddress: String,
+    val title: String,
+    val summary: String,
+    val thumbnail: String,
+    val tags: List<String>,
+    val likeCount: Long,
+    val createdAt: LocalDateTime,
+) {
+    @QueryProjection
+    constructor(post: Post, user: User) : this(
+        post.id,
+        user.id,
+        user.profile.image,
+        user.profile.nickname,
+        user.myTilAddress,
+        post.title,
+        post.summary,
+        post.thumbnail,
+        post.tags.items.map { it.name },
+        post.likeCount,
+        post.createdAt
+    )
+}


### PR DESCRIPTION
- entity 필드 중 getter가 있어야 하는 변수에 대해 private 접근 제어자를 제거했습니다 -> getter를 따로 뚫는게 나을지, 접근제어자를 제거하는게 나을지 고민해 봐야 할 것 같습니다. 편의상으로는 접근제어자 제거하는게 좋으나 var 필드라서 setter가 뚫려있는게 흠입니다.
- 무한 스크롤을 적용한다는 전제하에 쿼리를 작성했습니다. no offset 쿼리라서 스크롤을 내려 다음 페이지 조회시 마지막 게시물 id를 쿼리스트링에 포함해야 합니다.
- 특정 기간을 설정하여 조회하는 기능이 필요하다면 쿼리를 조금 변경해야 합니다. 디자인만 보고서는 감이 안와서 일단은 본인 글 조회하는것만 간단하게 구현해 봤습니다.