### PR TITLE
[TP-105] 화면 너비 축소 시 헤더 겹침 문제 해결

### DIFF
--- a/client/src/components/common/Header/Header.styles.tsx
+++ b/client/src/components/common/Header/Header.styles.tsx
@@ -3,13 +3,25 @@ import styled from '@emotion/styled';
 export const Header = styled.header`
   display: flex;
   width: 100%;
-  height: 64px;
-  justify-content: center;
+  min-height: 64px;
+  justify-content: start;
   padding: 0 48px 0 76px;
   white-space: nowrap;
 `;
 
-export const Navbar = styled.div`
+export const Left = styled.div`
+  display: flex;
+  justify-content: center;
+  @media (max-width: 1280px) {
+    height: 96px;
+    flex-direction: column;
+    justify-content: start;
+  }
+`;
+
+export const Navbar = styled.nav`
+  min-height: 64px;
+  margin-right: 18px;
   display: flex;
   align-items: center;
   text-align: center;
@@ -35,8 +47,9 @@ export const NavItem = styled.div<NavItemProps>`
 `;
 
 export const UserInfo = styled.div`
-  display: flex;
   margin-left: auto;
+  height: 64px;
+  display: flex;
   align-items: center;
 `;
 

--- a/client/src/components/common/Header/Header.tsx
+++ b/client/src/components/common/Header/Header.tsx
@@ -23,29 +23,31 @@ export default function Header(props: HeaderProps): JSX.Element {
 
   return (
     <Styled.Header>
-      <Styled.Navbar>
-        <Link href="/" passHref>
-          <Styled.Logo data-testid="logo">
-            <LogoIcon />
-            <LogoTitle />
-          </Styled.Logo>
-        </Link>
-        {NAV_ITEMS.map((item) => (
-          <Styled.NavItem
-            key={item.testId}
-            data-testid={item.testId}
-            active={active === item.href}
-          >
-            <Link href={item.href}>{item.title}</Link>
-          </Styled.NavItem>
-        ))}
+      <Styled.Left>
+        <Styled.Navbar>
+          <Link href="/" passHref>
+            <Styled.Logo data-testid="logo">
+              <LogoIcon />
+              <LogoTitle />
+            </Styled.Logo>
+          </Link>
+          {NAV_ITEMS.map((item) => (
+            <Styled.NavItem
+              key={item.testId}
+              data-testid={item.testId}
+              active={active === item.href}
+            >
+              <Link href={item.href}>{item.title}</Link>
+            </Styled.NavItem>
+          ))}
+        </Styled.Navbar>
         <SearchInput
           onSearch={onSearch}
           placeholder={
             '아이디, 닉네임, 태그, 텍스트와 본문을 검색해볼 수 있습니다'
           }
         />
-      </Styled.Navbar>
+      </Styled.Left>
       <Styled.UserInfo>
         {profile ? (
           <>

--- a/client/src/components/common/Header/SearchInput.styles.tsx
+++ b/client/src/components/common/Header/SearchInput.styles.tsx
@@ -13,7 +13,7 @@ interface ContainerProps {
 
 const activeCSS = css`
   width: 42.5vw;
-  padding: 0 12px;
+  padding: 0 4px 0 12px;
   border: 1px solid #cdcdcd;
   background-color: #ffffff;
   span:first-of-type {
@@ -21,20 +21,24 @@ const activeCSS = css`
   }
   input {
     visibility: visible;
-    width: 37.5vw;
+    width: 90%;
+  }
+  @media (max-width: 1280px) {
+    width: 60vw;
   }
 `;
 
 export const Container = styled.div<ContainerProps>`
   position: absolute;
-  display: flex;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
   width: 60px;
-  height: 30px;
-  margin: 18px;
   border: 0 solid #cdcdcd;
   border-radius: 8px;
-  background-color: transparent;
+  display: flex;
   align-items: center;
+  background-color: transparent;
   transition: width 0.35s;
 
   input {
@@ -55,6 +59,7 @@ export const Container = styled.div<ContainerProps>`
 export const Text = styled.span`
   position: absolute;
   white-space: nowrap;
+  font-size: 18px;
 `;
 
 export const Input = styled.input`
@@ -70,7 +75,7 @@ export const Input = styled.input`
 `;
 
 export const Icon = styled.span`
-  margin-top: 4px;
   margin-left: auto;
+  padding-top: 2px;
   cursor: pointer;
 `;


### PR DESCRIPTION
<img width="958" alt="스크린샷 2022-02-28 오후 10 41 53" src="https://user-images.githubusercontent.com/45786387/155993072-3d6dcb25-d535-4305-aaa1-987981a2ebd7.png">

1280px(wide 모니터) 아래로 내려가면 검색창을 아래로 보내 겹침문제를 해결했습니다.
이전에도 사용에 큰 불편함은 없었을 것 같지만,,,, 이 부분은 현주님께도 한 번 문의해봐야겠네요.

이렇게 변경한 이후에도 닉네임이 길면 여전히 조금씩 겹치긴 합니다 😢
<img width="1329" alt="스크린샷 2022-02-28 오후 10 45 08" src="https://user-images.githubusercontent.com/45786387/155993558-3b9b20a0-9904-4014-abe6-d18acefef411.png">

